### PR TITLE
Use native Netlify rust support

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "rustup install nightly && cargo +nightly doc --no-deps"
+  command = "rustup install nightly --profile minimal && cargo +nightly doc --no-deps"
   environment = { RUSTDOCFLAGS= "--cfg docsrs" }
   publish = "target/doc"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "cargo +nightly doc --no-deps"
+  command = "rustup install nightly && cargo +nightly doc --no-deps"
   environment = { RUSTDOCFLAGS= "--cfg docsrs" }
   publish = "target/doc"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,6 @@
 [build]
-  command = """
-  curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly --profile minimal \
-  && source $HOME/.cargo/env \
-  && RUSTDOCFLAGS=\"--cfg docsrs\" cargo +nightly doc --no-deps
-  """
+  command = "cargo +nightly doc --no-deps"
+  environment = { RUSTDOCFLAGS= "--cfg docsrs" }
   publish = "target/doc"
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
-  command = "rustup install nightly --profile minimal && cargo doc --no-deps"
+  command = "rustup install nightly --profile minimal && cargo doc --no-deps && cp -r target/doc _netlify_out"
   environment = { RUSTDOCFLAGS= "--cfg docsrs" }
-  publish = "target/doc"
+  publish = "_netlify_out"
 
 [[redirects]]
   from = "/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "rustup install nightly --profile minimal && cargo +nightly doc --no-deps"
+  command = "rustup install nightly --profile minimal && cargo doc --no-deps"
   environment = { RUSTDOCFLAGS= "--cfg docsrs" }
   publish = "target/doc"
 


### PR DESCRIPTION
## Motivation

At Netlify we recently introduced native Rust support in the build system: https://github.com/netlify/build-image/pull/477

## Solution

This PR cleans up the Netlify build config to use a more straight-forward way of building rust docs.